### PR TITLE
Make sekizai tests work on Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
  - 3.3
  - 3.4
  - 3.5
+ - 3.6
 env:
  - DJANGO='django>=1.3,<1.4'
  - DJANGO='django>=1.4,<1.5'
@@ -14,6 +15,7 @@ env:
  - DJANGO='django>=1.8,<1.9'
  - DJANGO='django>=1.9,<1.10'
  - DJANGO='django>=1.10,<1.11'
+ - DJANGO='django>=1.11,<1.12'
 install:
  - pip install $DJANGO django-classy-tags pycodestyle backport-collections
 script: python runtests.py
@@ -29,6 +31,8 @@ matrix:
       env: DJANGO='django>=1.9,<1.10'
     - python: 3.3
       env: DJANGO='django>=1.10,<1.11'
+    - python: 3.3
+      env: DJANGO='django>=1.11,<1.12'
     - python: 3.4
       env: DJANGO='django>=1.3,<1.4'
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
  - DJANGO='django>=1.9,<1.10'
  - DJANGO='django>=1.10,<1.11'
 install:
- - pip install $DJANGO django-classy-tags pep8 backport-collections
+ - pip install $DJANGO django-classy-tags pycodestyle backport-collections
 script: python runtests.py
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,19 @@ matrix:
       env: DJANGO='django>=1.6,<1.7'
     - python: 3.5
       env: DJANGO='django>=1.7,<1.8'
+    - python: 3.6
+      env: DJANGO='django>=1.3,<1.4'
+    - python: 3.6
+      env: DJANGO='django>=1.4,<1.5'
+    - python: 3.6
+      env: DJANGO='django>=1.5,<1.6'
+    - python: 3.6
+      env: DJANGO='django>=1.6,<1.7'
+    - python: 3.6
+      env: DJANGO='django>=1.7,<1.8'
+    - python: 3.6
+      env: DJANGO='django>=1.8,<1.9'
+    - python: 3.6
+      env: DJANGO='django>=1.9,<1.10'
+    - python: 3.6
+      env: DJANGO='django>=1.10,<1.11'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,8 @@ sekizai will ignore any duplicate content in a single block.
 Dependencies
 ************
 
-* Python 2.7, 3.3, 3.4 or 3.5.
-* Django 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9 or 1.10.
+* Python 2.7, 3.3, 3.4, 3.5 or 3.6.
+* Django 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10 or 1.11.
 * django-classy-tags 0.3.1 or higher.
 
 *****
@@ -58,7 +58,8 @@ steps:
     
     or
 
-    * Use ``sekizai.context.SekizaiContext`` when rendering your templates.
+    * For Django versions before 1.11, use ``sekizai.context.SekizaiContext``
+      when rendering your templates.
 
 
 Template Tag Reference

--- a/sekizai/templatetags/sekizai_tags.py
+++ b/sekizai/templatetags/sekizai_tags.py
@@ -97,6 +97,8 @@ class RenderBlock(Tag):
             func = import_processor(postprocessor)
             data = func(context, data, name)
         return '%s\n%s' % (data, rendered_contents)
+
+
 register.tag('render_block', RenderBlock)
 
 
@@ -112,6 +114,8 @@ class AddData(SekizaiTag):
         varname = get_varname()
         context[varname][key].append(value)
         return ''
+
+
 register.tag('add_data', AddData)
 
 
@@ -137,6 +141,8 @@ class WithData(SekizaiTag):
         inner_contents = inner_nodelist.render(context)
         context.pop()
         return '%s\n%s' % (inner_contents, rendered_contents)
+
+
 register.tag('with_data', WithData)
 
 
@@ -161,4 +167,6 @@ class Addtoblock(SekizaiTag):
         varname = get_varname()
         context[varname][name].append(rendered_contents)
         return ""
+
+
 register.tag('addtoblock', Addtoblock)

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 import pycodestyle
 
+from sekizai import context_processors
 from sekizai.context import SekizaiContext
 from sekizai.helpers import get_namespaces
 from sekizai.helpers import get_varname
@@ -204,8 +205,10 @@ class SekizaiTestCase(TestCase):
         settings.TEMPLATE_DIRS = cls._template_dirs
 
     def _render(self, tpl, ctx=None, ctxclass=SekizaiContext):
-        ctx = ctx or {}
-        return render_to_string(tpl, ctxclass(ctx))
+        ctx = dict(ctx) if ctx else {}
+        if ctxclass == SekizaiContext:
+            ctx.update(context_processors.sekizai())
+        return render_to_string(tpl, dict(ctx))
 
     def _get_bits(self, tpl, ctx=None, ctxclass=SekizaiContext):
         ctx = ctx or {}

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -206,7 +206,7 @@ class SekizaiTestCase(TestCase):
 
     def _render(self, tpl, ctx=None, ctxclass=SekizaiContext):
         ctx = dict(ctx) if ctx else {}
-        if ctxclass == SekizaiContext:
+        if issubclass(ctxclass, SekizaiContext):
             ctx.update(context_processors.sekizai())
         return render_to_string(tpl, ctx)
 

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -8,7 +8,7 @@ import django
 from django import template
 from django.conf import settings
 from django.template.loader import render_to_string
-import pep8
+import pycodestyle
 
 from sekizai.context import SekizaiContext
 from sekizai.helpers import get_namespaces
@@ -229,7 +229,7 @@ class SekizaiTestCase(TestCase):
 
     def test_pep8(self):
         sekizai_dir = os.path.dirname(os.path.abspath(__file__))
-        pep8style = pep8.StyleGuide()
+        pep8style = pycodestyle.StyleGuide()
         with CaptureStdout() as stdout:
             result = pep8style.check_files([sekizai_dir])
             errors = stdout.getvalue()

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -208,7 +208,7 @@ class SekizaiTestCase(TestCase):
         ctx = dict(ctx) if ctx else {}
         if ctxclass == SekizaiContext:
             ctx.update(context_processors.sekizai())
-        return render_to_string(tpl, dict(ctx))
+        return render_to_string(tpl, ctx)
 
     def _get_bits(self, tpl, ctx=None, ctxclass=SekizaiContext):
         ctx = ctx or {}

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     install_requires=[
         'django-classy-tags>=0.3.1',
     ],
+    tests_require=[
+        'pycodestyle',
+    ],
     test_suite='runtests.main',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The main issue is that Django 1.11 no longer allows Contexts to be used as, er, contexts.

It also required dealing with pep8's rename to pycodestyle.