### PR TITLE
Fix import for django>=3.1

### DIFF
--- a/sekizai/helpers.py
+++ b/sekizai/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.template.base import Context, Template, Variable, VariableNode
+from django.template import Context
+from django.template.base import Template, Variable, VariableNode
 from django.template.loader import get_template
 from django.template.loader_tags import BlockNode, ExtendsNode
 


### PR DESCRIPTION
Context is not imported into django.template.base anymore.